### PR TITLE
Flexible cosmology

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## v0.1.2-git (unreleased)
+* clusters.ClusterEnsemble() accepts input cosmology as any astropy.cosmology object
 
 ## v0.1.1 (18 Mar 2016) -- minor API update
 * fixed miss-spelling of "richness" in function names:

--- a/clusterlensing/clusters.py
+++ b/clusterlensing/clusters.py
@@ -170,9 +170,9 @@ class ClusterEnsemble(object):
 
     Other Parameters
     ----------------
-    cosmology : str, optional
-        Cosmology to use in calculations, default 'Planck13'. Other choices
-        are 'WMAP9', 'WMAP7', and 'WMAP5'.
+    cosmology : astropy.cosmology instance, optional
+        Cosmology to use in calculations, default astropy.cosmology.Planck13.
+        Must be an instance of astropy.cosmology with 'h' and 'Om0' attributes.
     cm : str, optional
         Concentration-mass relation to use, default 'DuttonMaccio'. Other
         choices are 'Prada' and 'Duffy'.


### PR DESCRIPTION
Now, instead of specifying cosmology as one of a limited number of strings {"WMAP9", "WMAP7", "WMAP5", "Planck13"}, the user passes in an instance of astropy.cosmology to the ClusterEnsemble() class. The default cosmology used is still astropy.cosmology.Planck13. This fixes #2.
